### PR TITLE
Cloudflare branch and other things

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,36 +4,55 @@
 
 ## How to create environement for TP
 
-TF_VAR_users_list is very important, it is the lit of student you have in your group. (and will be used to know how many vms you will provision : TF_VAR_vm_number)
+TF_VAR_users_list is very important, it is the list of student you have in your group. (and will be used to know how many vms you will provision : TF_VAR_vm_number)
 
 
 For the IaC TP (with API keys). This number is used so the accounts (API Key) are spread on the 7 european available regions (we keep Paris for the TP vms) in a round robin way. This means that if you have more than 14 students (including trainer), you will have more than 2 accounts per region
 
 TF_VAR_tp_name is also very important to correctly set up depending on which TP you are doing
 
-You need to export vars, you can use a .env or export script
+You need to export vars, you can use a .env or export script wherever you want (do not forget to source it before launching terraform or other scripts)
 ```bash
 export TF_VAR_users_list='{
-  "iac00": {"name": "John Doe"},
-  "iac01": {"name": "Alice Doe"}
+  "vm00": {"name": "John Doe"},
+  "vm01": {"name": "Alice Doe"}
 }'
 export TF_VAR_vm_number=$(echo ${TF_VAR_users_list} | jq length)
 export TF_VAR_monitoring_user="**********" #password will be the same to simplify
 export TF_VAR_AccessDocs_vm_enabled=true   # Guacamole and docs (webserver for publishing docs with own DNS record)
 export TF_VAR_tp_name="tpiac"   # Choose between tpiac and tpkube to load specific user_data
 export TF_VAR_kube_multi_node=false # Add one (or more VM) to add a second node for Kube cluster
-export TF_VAR_tpcsws_branch_name=master # This is used for which branch of tpcs-workstation git repo to target in scripts (actually used for Grafana Dashboards)
-export TF_VAR_acme_certificates_enable=false
+export TF_VAR_tpcsws_branch_name="master" # This is used for which branch of tpcs-workstations git repo to target in scripts (actually used for Grafana Dashboards)
+export TF_VAR_tpcsws_git_repo="seb54000/tpcs-workstations" # Used in case this git repo would be forked
+export TF_VAR_acme_certificates_enable=false # As Let's encrypt ACME Protocol has limits : https://letsencrypt.org/docs/rate-limits/#new-certificates-per-registered-domain  # You can visit this website to see las certificates https://crt.sh/?q=%25.tpcsonline.org&identity=%25.tpcsonline.org&deduplicate=Y # Or curl 'https://crt.sh/?q=%25.tpcsonline.org&output=json' to automate with jq
+export TF_VAR_dns_subdomain="seb.tpcsonline.org" # You shoud only use tpcsonline.org when you're doing class
 
 export AWS_ACCESS_KEY_ID=********************************
 export AWS_SECRET_ACCESS_KEY=********************************
 export AWS_DEFAULT_REGION=eu-west-3 # Paris
-export TF_VAR_ovh_endpoint=ovh-eu
-export TF_VAR_ovh_application_key=************
-export TF_VAR_ovh_application_secret=************
-export TF_VAR_ovh_consumer_key=************
+export TF_VAR_cloudflare_api_token=************
 export TF_VAR_token_gdrive="************"
+export TF_VAR_copy_from_gdrive=false # Decide if copy of TP documents on docs vm will be done automatically (but for that, you need to have a valid token_gdrive and access to Gdrive)
 ```
+
+In case you need to install terraform
+```bash
+curl -o tf.zip https://releases.hashicorp.com/terraform/1.11.2/terraform_1.11.2_linux_amd64.zip
+unzip tf.zip && rm tf.zip
+sudo mv terraform /usr/local/bin/terraform
+```
+
+Generate an RSA keys pair and copy it in terraform-infra directory with generic names key and key.pub:
+
+```bash
+ ssh-keygen -t rsa -b 4096 # You can choose a different algorithm than rsa
+ cp $HOME/.ssh/id_rsa.pub ./terraform-infra/key.pub
+ cp $HOME/.ssh/id_rsa ../terraform-infra/key
+```
+- http://access.tpcsonline.org
+- http://docs.tpcsonline.org
+- http://vmxx.tpcsonline.org
+
 
 :warning: IMPORTANT : Review the list of files you want to be downloaded from Gdrive and become available on the docs servers
 - It is at the end of the variables.tf file - look for `tpiac_docs_file_list`, `tpmon_docs_file_list` and `tpkube_docs_file_list`
@@ -47,37 +66,31 @@ Need to upload the files manually for the moment, much more quicker on a machine
   - Copy the files from FUSE gdrive to a temporary local dir
     - or open a shell from the FUSE gdrive folder (in nautilus explorer, right click)
   - SCP :
-    - `ssh -i $(pwd)/key access@docs.tpcs.multiseb.com 'chmod 777 /var/www/html'`
-    - `scp -i $(pwd)/key /var/tmp/my-file access@docs.tpcs.multiseb.com:/var/www/html/`
-Then simply terraform init/plan/apply and point your browser to the different URLs :
+    - `ssh -i $(pwd)/key access@docs.tpcsonline.org 'chmod 777 /var/www/html'`
+    - `scp -i $(pwd)/key /var/tmp/my-file access@docs.tpcsonline.org:/var/www/html/`
 
-In case you need to install terraform
-```bash
-curl -o tf.zip https://releases.hashicorp.com/terraform/1.6.6/terraform_1.6.6_linux_amd64.zip
-unzip tf.zip && rm tf.zip
-sudo mv terraform /usr/local/bin/terraform
-```
 
-- http://access.tpcs.multiseb.com
-- http://docs.tpcs.multiseb.com
-- http://vmxx.tpcs.multiseb.com
 
-ssh-keygen -f "/home/seb/.ssh/known_hosts" -R "docs.tpcs.multiseb.com"
-ssh -i $(pwd)/key access@docs.tpcs.multiseb.com
+
+ssh-keygen -f "$HOME/.ssh/known_hosts" -R "docs.tpcsonline.org"
+ssh -i $(pwd)/key access@docs.tpcsonline.org
 
 :warning: IMPORTANT : go to the docs vm and look at the quotas.php page and take a "screenshot" to know the actual quotas at the begining of the TP, we should have the same usage at the end
+
+Change guacadmin password in the web interface : Connect to the guacamole web interface : http://access.tpcsonline.org with guacadmin user and same password.
+Click on your user at the top right of the Screen. Then "Paramètre", "Préférences" and you'll find a section to change your password
 
 ## VMs provisioning and AK/SK overview
 
 ![overview.excalidraw.png](overview.excalidraw.png?raw=true "overview.excalidraw.png")
 
 ## Debug cloud Init or things that could go wrong
-
+```bash
 sudo cloud-init status --long
 sudo cat /var/log/cloud-init-output.log
 sudo cat /var/log/user-data-common.log
 sudo cat /var/log/user-data.log
-
+```
 Once I had this error in the /var/log/user-data.log for docs vm :
 
   - google.auth.exceptions.RefreshError: ('invalid_grant: Bad Request', {'error': 'invalid_grant', 'error_description': 'Bad Request'})
@@ -154,8 +167,8 @@ for ((i=0; i<$TF_VAR_vm_number; i++))
 do
   digits=$(printf "%02d" $i)
   echo "terraform destroy in vm${digits} :"
-  ssh-quiet -i $(pwd)/key vm${digits}@vm${digits}.tpcs.multiseb.com "terraform -chdir=/home/vm${digits}/tpcs-iac/terraform/ destroy -auto-approve" | tee -a /var/tmp/tfdestroy-vm${digits}-$(date +%Y%m%d-%H%M%S)
-  ssh-quiet -i $(pwd)/key vm${digits}@vm${digits}.tpcs.multiseb.com "source /home/vm${digits}/tpcs-iac/.env && terraform -chdir=/home/vm${digits}/tpcs-iac/vikunja/terraform/ destroy -auto-approve" | tee -a /var/tmp/tfdestroy-vm${digits}-$(date +%Y%m%d-%H%M%S)
+  ssh-quiet -i $(pwd)/key vm${digits}@vm${digits}.tpcsonline.org "terraform -chdir=/home/vm${digits}/tpcs-iac/terraform/ destroy -auto-approve" | tee -a /var/tmp/tfdestroy-vm${digits}-$(date +%Y%m%d-%H%M%S)
+  ssh-quiet -i $(pwd)/key vm${digits}@vm${digits}.tpcsonline.org "source /home/vm${digits}/tpcs-iac/.env && terraform -chdir=/home/vm${digits}/tpcs-iac/vikunja/terraform/ destroy -auto-approve" | tee -a /var/tmp/tfdestroy-vm${digits}-$(date +%Y%m%d-%H%M%S)
 done
 
 grep -e destroyed -e vm /var/tmp/tfdestroy-vm*
@@ -171,10 +184,10 @@ for ((i=0; i<$TF_VAR_vm_number; i++))
 do
   digits=$(printf "%02d" $i)
   echo "VM : vm0${i}"
-  # ssh-keygen -f "$(ls ~/.ssh/known_hosts)" -R "vm${digits}.tpcs.multiseb.com" 2&> /dev/null
-  ssh-quiet -i $(pwd)/key vm${digits}@vm${digits}.tpcs.multiseb.com 'sudo growpart /dev/xvda 1'
-  ssh-quiet -i $(pwd)/key vm${digits}@vm${digits}.tpcs.multiseb.com 'sudo resize2fs /dev/xvda1'
-  ssh-quiet -i $(pwd)/key vm${digits}@vm${digits}.tpcs.multiseb.com 'df -h /'
+  # ssh-keygen -f "$(ls ~/.ssh/known_hosts)" -R "vm${digits}.tpcsonline.org" 2&> /dev/null
+  ssh-quiet -i $(pwd)/key vm${digits}@vm${digits}.tpcsonline.org 'sudo growpart /dev/xvda 1'
+  ssh-quiet -i $(pwd)/key vm${digits}@vm${digits}.tpcsonline.org 'sudo resize2fs /dev/xvda1'
+  ssh-quiet -i $(pwd)/key vm${digits}@vm${digits}.tpcsonline.org 'df -h /'
 done
 ```
 
@@ -193,14 +206,14 @@ cd ~/tp-cs-containers-student/kubernetes/vikunja
 kubectl apply -f vikunja.kube.complete.yml
 kubectl get po
 
-curl https://vm00.tpcs.multiseb.com/
+curl https://vm00.tpcsonline.org/
 
-# Double check the API URL should be something like vm00.tpcs.multiseb.com/api (as there is a kubernetes ingress listening on path /api forwarging to api service on port 3456 but you don't need port)
+# Double check the API URL should be something like vm00.tpcsonline.org/api (as there is a kubernetes ingress listening on path /api forwarging to api service on port 3456 but you don't need port)
 
 # Also check in kube file (vikunja.kube.complete.yml) :
 #           - name: VIKUNJA_API_URL
-#             value: vm00.tpcs.multiseb.com/api
-# And also the VIkunja install URL should be vm00.tpcs.multiseb.com/api/v1
+#             value: vm00.tpcsonline.org/api
+# And also the VIkunja install URL should be vm00.tpcsonline.org/api/v1
 
 ```
 
@@ -209,8 +222,8 @@ curl https://vm00.tpcs.multiseb.com/
 
 A prometheus and Grafana docker instances are installed on monitoring (which is actually shared with access and docs)
 
-- You can acces grafana through https://monitoring.tpcs.multiseb.com (or also https://grafana.tpcs.multiseb.com) - admin username is monitoring (you have to guess the password)
-- Prometheus can be reached https://prometheus.tpcs.multiseb.com
+- You can acces grafana through https://monitoring.tpcsonline.org (or also https://grafana.tpcsonline.org) - admin username is monitoring (you have to guess the password)
+- Prometheus can be reached https://prometheus.tpcsonline.org
 
 ## Add microk8s additional nodes (work in progress)
 
@@ -230,7 +243,7 @@ If you want to monitor the additional nodes in Prometheus, you will have to deit
 
 ```bash
 sudo vi /var/tmp/prometheus.yml
-        - knode00.tpcs.multiseb.com:9100
+        - knode00.tpcsonline.org:9100
 
 docker-compose -f monitoring_docker_compose.yml restart
 ```
@@ -286,7 +299,7 @@ metadata:
     name: bgd
 spec:
  rules:
- - host: vm00.tpcs.multiseb.com
+ - host: vm00.tpcsonline.org
    http:
      paths:
      - pathType: Prefix
@@ -301,7 +314,7 @@ spec:
 
 ## TODOs :
 
-- [X] Add variable to choose if we want real ACME certificates or selfsigned (because when doing multiple create and destroy tests, we can block the certificates issuance as it is limited to a certain number)
+- [ ] Need to check that dns_subdomain var is really working with grafana dahsboards : terraform-infra/cloudinit/monitoring_grafana_node_full_dashboard.json
 - [ ] Remove VScode extension like kube when not installed (top monitoring ?)
 - [ ] TODO add jinja if custom_files is not empty (cloud-config.yaml.tftpl) -- for knode otherwise cloud-inint error
 - [ ] Envisage only one setup for the student VM including tpiac and tpkube prereqs (will be needed for IaC extension on Kube - or maybe we will use an AWS kubernetes cluster only for TPiAC extension ??).
@@ -383,6 +396,12 @@ spec:
 - [X] Add links to access, monitoring and other useful infos in docs webserver
 - [X] Export google documents in PDF (Do not need to already have them in PDF)
 - [X] Do not create IAM tp_iac ressources for tpkube and tpmon (to save very little on AWS account)
+- [X] Add acme_certificates_enable variable to choose if we want real ACME certificates or selfsigned (because when doing multiple create and destroy tests, we can block the certificates issuance as it is limited to a certain number)
+- [X] Add a copy_from_gdrive var to decide if documents should be automatically copied form Gdrive to docs (needs grdive token)
+- [X] Remove the vms with a status of terminated (removed) in the vms.php listing
+- [X] Use a tpcsonline.org domain on Cloudflare more reliable than OVH
+  - [X] add a dns_subdomain var to enable parralel working like access.xxx.tpcsonline.org
+- [X] Add a script (07) to check certificates delivered in the last 7 days (to check letsencrypt limit)
 
 ## API access settings to Gdrive (Google Drive)
 

--- a/terraform-infra/.gitignore
+++ b/terraform-infra/.gitignore
@@ -6,7 +6,8 @@
 *.tfstate..lock*
 key
 key.pub
-
+id_rsa.pub
+id_rsa
 *credentials-setup.sh
 .env
 .DS_Store

--- a/terraform-infra/cloudinit/access_docs_nginx.conf.tpl
+++ b/terraform-infra/cloudinit/access_docs_nginx.conf.tpl
@@ -5,7 +5,7 @@ server {
         root /var/www/html;
         index index.html index.htm index.nginx-debian.html;
 
-        server_name access.tpcs.multiseb.com www.access.tpcs.multiseb.com;
+        server_name access.${dns_subdomain} www.access.${dns_subdomain};
         location / {
                 proxy_pass  https://127.0.0.1:8443;
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -27,7 +27,7 @@ server {
         charset utf-8;
         }
 
-        server_name docs.tpcs.multiseb.com www.docs.tpcs.multiseb.com;
+        server_name docs.${dns_subdomain} www.docs.${dns_subdomain};
         # pass PHP scripts on Nginx to FastCGI (PHP-FPM) server
 
         location ~ \.php$ {
@@ -44,7 +44,7 @@ server {
         listen 80;
         listen [::]:80;
 
-        server_name monitoring.tpcs.multiseb.com www.monitoring.tpcs.multiseb.com;
+        server_name monitoring.${dns_subdomain} www.monitoring.${dns_subdomain};
         location / {
                 proxy_pass  http://127.0.0.1:3000;
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -59,7 +59,7 @@ server {
         listen 80;
         listen [::]:80;
 
-        server_name prometheus.tpcs.multiseb.com www.prometheus.tpcs.multiseb.com;
+        server_name prometheus.${dns_subdomain} www.prometheus.${dns_subdomain};
         location / {
                 proxy_pass  http://127.0.0.1:9090;
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -74,7 +74,7 @@ server {
         listen 80;
         listen [::]:80;
 
-        server_name grafana.tpcs.multiseb.com www.grafana.tpcs.multiseb.com;
+        server_name grafana.${dns_subdomain} www.grafana.${dns_subdomain};
         location / {
                 proxy_pass  http://127.0.0.1:3000;
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/terraform-infra/cloudinit/check_basics.sh.tftpl
+++ b/terraform-infra/cloudinit/check_basics.sh.tftpl
@@ -6,6 +6,6 @@ for ((i=0; i<vm_number; i++))
 do
   digits=$(printf "%02d" $i)
   echo "VM : vm0$i"
-  ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $(pwd)/key vm$digits@vm$digits.tpcs.multiseb.com 'hostname'
-  ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $(pwd)/key vm$digits@vm$digits.tpcs.multiseb.com 'cat /home/ubuntu/user_data_student_finished && echo "cloudinit finished" || echo "cloudinit still ongoing"'
+  ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $(pwd)/key vm$digits@vm$digits.${dns_subdomain} 'hostname'
+  ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $(pwd)/key vm$digits@vm$digits.${dns_subdomain} 'cat /home/ubuntu/user_data_student_finished && echo "cloudinit finished" || echo "cloudinit still ongoing"'
 done

--- a/terraform-infra/cloudinit/monitoring_grafana_node_full_dashboard.json
+++ b/terraform-infra/cloudinit/monitoring_grafana_node_full_dashboard.json
@@ -23470,8 +23470,8 @@
       },
       {
         "current": {
-          "text": "vm03.tpcs.multiseb.com:9100",
-          "value": "vm03.tpcs.multiseb.com:9100"
+          "text": "vm03.${dns_subdomain}:9100",
+          "value": "vm03.${dns_subdomain}:9100"
         },
         "datasource": {
           "type": "prometheus",

--- a/terraform-infra/cloudinit/prometheus_config.tftpl
+++ b/terraform-infra/cloudinit/prometheus_config.tftpl
@@ -18,9 +18,9 @@ scrape_configs:
     static_configs:
       - targets:
         - localhost:9090
-        - docs.tpcs.multiseb.com:9100
-        - access.tpcs.multiseb.com:9100
-        - monitoring.tpcs.multiseb.com:9100
+        - docs.${dns_subdomain}:9100
+        - access.${dns_subdomain}:9100
+        - monitoring.${dns_subdomain}:9100
       %{ for i in range(vm_number) }
-        - ${format("vm%02d", i)}.tpcs.multiseb.com:9100
+        - ${format("vm%02d", i)}.${dns_subdomain}:9100
       %{ endfor }

--- a/terraform-infra/cloudinit/user_data_access_docs.sh
+++ b/terraform-infra/cloudinit/user_data_access_docs.sh
@@ -41,7 +41,7 @@ sudo su - ${username} -c "cd guacamole-docker-compose && git clean -df"
 if [[ "${acme_certificates_enable}" == "true" ]]
 then
     # Certificate is valid for 90 days, more than enough for our use case - no need to renew
-    sudo certbot --nginx -d docs.${dns_subdomain} -d www.docs.${dns_subdomain} \
+    sudo certbot --nginx -d access.${dns_subdomain} -d www.access.${dns_subdomain} \
         --non-interactive --agree-tos \
         --no-eff-email \
         --no-redirect \

--- a/terraform-infra/cloudinit/vms.php
+++ b/terraform-infra/cloudinit/vms.php
@@ -6,24 +6,25 @@ $region = shell_exec("curl -s http://169.254.169.254/latest/meta-data/placement/
 // Chargement du fichier JSON des correspondances utilisateur
 $userMapping = json_decode(file_get_contents('/var/www/html/json/users.json'), true);
 
+$tptype = file_get_contents('/var/www/html/json/tp_name');
+$dns_subdomain = file_get_contents('/var/www/html/json/dns_subdomain');
 // Chargement du fichier JSON des clés d'API
 if ($tptype == "tpiac") {
     $apiKeys = json_decode(file_get_contents('/var/www/html/json/api_keys.json'), true);
 }
 
-$tptype = file_get_contents('/var/www/html/json/tp_name');
 echo "<h1>TP type : " .htmlspecialchars($tptype). "</h1>";
 
 echo "Votre nom d'utilisateur est unique pour tous les usages : user guacamole, user vm, user AWS console. Le mot de passe est identique au username (sauf pour console AWS cf. ci-dessous)</br>";
 echo "<i>Si besoin vous pouvez vous connectez directement à la vm (via SSH ou RDP) en utilisant le Record DNS (chercher la colonne).</i></br>";
-echo "<i>  Exemple : ssh vmxx@vmxx.tpcs.multiseb.com (ou utiliser un client RDP)</i></br>";
+echo "<i>  Exemple : ssh vmxx@vmxx.${dns_subdomain} (ou utiliser un client RDP)</i></br>";
 
 if ($tptype == "tpiac") {
     echo "Les mots de passe pour console AWS et clé secrète d'API sont dans le fichier <b>/home/vmXX/tpcs-iac/.env</b> sur chacune de vos VMs</br></br>";
     echo "<h3><a href=\"https://tpiac.signin.aws.amazon.com/console/\" target=\"_blank\">Accès console AWS</a></h3>";
 }
 
-echo "<h3><a href=\"https://access.tpcs.multiseb.com/\" target=\"_blank\">Accès Guacamole (bureau RDP pour votre VM)</a></h3>";
+echo "<h3><a href=\"https://access.${dns_subdomain}/\" target=\"_blank\">Accès Guacamole (bureau RDP pour votre VM)</a></h3>";
 
 
 // En-tête du tableau HTML
@@ -37,7 +38,7 @@ if ($tptype == "tpiac") {
 }
 echo        "<th>Adresse IP de la VM</th>
             <th>Record DNS</th>
-            <th>Adresse IP associée actuellement</th>
+            <th>Adresse IP du record DNS</th>
             <th>Statut de la VM</th>
         </tr>";
 
@@ -45,8 +46,19 @@ echo        "<th>Adresse IP de la VM</th>
 foreach ($userMapping as $user => $userData) {
     $UserRealName = $userData['name'];
 
-    // Exécuter la commande AWS CLI pour obtenir les détails de l'instance
-    $instanceOutput = shell_exec("aws ec2 describe-instances --region $region --output json --filters Name=tag:Name,Values=vm" . substr($user, 2) . " --query 'Reservations[].Instances[].[InstanceId,PublicIpAddress,Tags[?Key==`Name`]|[0].Value,Tags[?Key==`AUTO_DNS_NAME`]|[0].Value,State.Name]' 2>&1");
+    // Exécuter la commande AWS CLI pour obtenir les détails de l'instance (we want all status except terminated/removed)
+    $instanceName = 'vm' . substr($user, -2);
+    $cmd = "aws ec2 describe-instances "
+         . "--region $region "
+         . "--output json "
+         . "--filters "
+         . "Name=tag:Name,Values=$instanceName "
+         . "Name=instance-state-name,Values=pending,running,shutting-down,stopping,stopped "
+         . "--query 'Reservations[].Instances[].[InstanceId,PublicIpAddress,"
+         . "Tags[?Key==`Name`]|[0].Value,"
+         . "Tags[?Key==`AUTO_DNS_NAME`]|[0].Value,"
+         . "State.Name]'";
+    $instanceOutput = shell_exec($cmd);
 
     // Décoder la sortie JSON
     $instanceDetails = json_decode($instanceOutput, true);
@@ -78,10 +90,10 @@ foreach ($userMapping as $user => $userData) {
             }
 
             echo "<td>{$instance[1]}</td>";
-            echo "<td>{$instance[2]}.tpcs.multiseb.com</td>";
+            echo "<td>{$instance[2]}.${dns_subdomain}</td>";
 
             // Exécuter un lookup pour obtenir l'adresse IP associée au record DNS
-            $dnsIp = shell_exec("nslookup {$instance[2]}.tpcs.multiseb.com 2>&1 | grep -Eo 'Address: ([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)' | cut -d' ' -f2");
+            $dnsIp = shell_exec("dig +short {$instance[2]}.${dns_subdomain} 2>&1");
             echo "<td>{$dnsIp}</td>";
 
             echo "<td>{$instance[4]}</td>";

--- a/terraform-infra/dns-records.tf
+++ b/terraform-infra/dns-records.tf
@@ -1,108 +1,126 @@
 
-resource "ovh_domain_zone_record" "student_vm" {
+resource "cloudflare_dns_record" "student_vm" {
   count   = var.vm_number
-  zone      = "multiseb.com"
-  subdomain = "${format("vm%02s.tpcs", count.index)}"
-  fieldtype = "A"
+  zone_id = var.cloudflare_zone_id
+  name = "${format("vm%02s", count.index)}.${var.dns_subdomain}"
+  type = "A"
   ttl       = 60
-  target    = aws_instance.student_vm[count.index].public_ip
+  content    = aws_instance.student_vm[count.index].public_ip
 }
 
-resource "ovh_domain_zone_record" "kube_node_vm" {
-  count = var.kube_multi_node == true ? var.vm_number : 0
-  zone      = "multiseb.com"
-  subdomain = "${format("knode%02s.tpcs", count.index)}"
-  fieldtype = "A"
+resource "cloudflare_dns_record" "kube_node_vm" {
+  count   = var.kube_multi_node == true ? var.vm_number : 0
+  zone_id = var.cloudflare_zone_id
+  name = "${format("knode%02s", count.index)}.${var.dns_subdomain}"
+  type = "A"
   ttl       = 60
-  target    = aws_instance.kube_node_vm[count.index].public_ip
+  content    = aws_instance.kube_node_vm[count.index].public_ip
 }
 
-resource "ovh_domain_zone_record" "docs" {
+resource "cloudflare_dns_record" "docs" {
+  count   = var.AccessDocs_vm_enabled ? 1 : 0
+  zone_id = var.cloudflare_zone_id
+  name = "docs.${var.dns_subdomain}"
+  type = "A"
+  ttl       = 60
+  content    = aws_instance.access[0].public_ip
+}
+
+resource "cloudflare_dns_record" "www_docs" {
+  count   = var.AccessDocs_vm_enabled ? 1 : 0
+  zone_id = var.cloudflare_zone_id
+  name = "www.docs.${var.dns_subdomain}"
+  type = "A"
+  ttl       = 60
+  content    = aws_instance.access[0].public_ip
+}
+
+resource "cloudflare_dns_record" "access" {
+  count   = var.AccessDocs_vm_enabled ? 1 : 0
+  zone_id = var.cloudflare_zone_id
+  name = "access.${var.dns_subdomain}"
+  type = "A"
+  ttl       = 60
+  content    = aws_instance.access[0].public_ip
+}
+
+resource "cloudflare_dns_record" "www_access" {
+  count   = var.AccessDocs_vm_enabled ? 1 : 0
+  zone_id = var.cloudflare_zone_id
+  name = "www.access.${var.dns_subdomain}"
+  type = "A"
+  ttl       = 60
+  content    = aws_instance.access[0].public_ip
+}
+
+resource "cloudflare_dns_record" "monitoring" {
+  count   = var.AccessDocs_vm_enabled ? 1 : 0
+  zone_id = var.cloudflare_zone_id
+  name = "monitoring.${var.dns_subdomain}"
+  type = "A"
+  ttl       = 60
+  content    = aws_instance.access[0].public_ip
+}
+
+resource "cloudflare_dns_record" "www_monitoring" {
   count = "${var.AccessDocs_vm_enabled ? 1 : 0}"
-  zone      = "multiseb.com"
-  subdomain = "docs.tpcs"
-  fieldtype = "A"
+  zone_id = var.cloudflare_zone_id
+  name = "www.monitoring.${var.dns_subdomain}"
+  type = "A"
   ttl       = 60
-  target    = aws_instance.access[0].public_ip
+  content    = aws_instance.access[0].public_ip
 }
 
-resource "ovh_domain_zone_record" "www_docs" {
+resource "cloudflare_dns_record" "prometheus" {
   count = "${var.AccessDocs_vm_enabled ? 1 : 0}"
-  zone      = "multiseb.com"
-  subdomain = "www.docs.tpcs"
-  fieldtype = "A"
+  zone_id = var.cloudflare_zone_id
+  name = "prometheus.${var.dns_subdomain}"
+  type = "A"
   ttl       = 60
-  target    = aws_instance.access[0].public_ip
+  content    = aws_instance.access[0].public_ip
 }
 
-resource "ovh_domain_zone_record" "access" {
+resource "cloudflare_dns_record" "www_prometheus" {
   count = "${var.AccessDocs_vm_enabled ? 1 : 0}"
-  zone      = "multiseb.com"
-  subdomain = "access.tpcs"
-  fieldtype = "A"
+   zone_id = var.cloudflare_zone_id
+  name = "www.prometheus.${var.dns_subdomain}"
+  type = "A"
   ttl       = 60
-  target    = aws_instance.access[0].public_ip
+  content    = aws_instance.access[0].public_ip
 }
 
-resource "ovh_domain_zone_record" "www_access" {
+resource "cloudflare_dns_record" "grafana" {
   count = "${var.AccessDocs_vm_enabled ? 1 : 0}"
-  zone      = "multiseb.com"
-  subdomain = "www.access.tpcs"
-  fieldtype = "A"
+   zone_id = var.cloudflare_zone_id
+  name = "grafana.${var.dns_subdomain}"
+  type = "A"
   ttl       = 60
-  target    = aws_instance.access[0].public_ip
+  content    = aws_instance.access[0].public_ip
 }
 
-resource "ovh_domain_zone_record" "monitoring" {
+resource "cloudflare_dns_record" "www_grafana" {
   count = "${var.AccessDocs_vm_enabled ? 1 : 0}"
-  zone      = "multiseb.com"
-  subdomain = "monitoring.tpcs"
-  fieldtype = "A"
+   zone_id = var.cloudflare_zone_id
+  name = "www.grafana.${var.dns_subdomain}"
+  type = "A"
   ttl       = 60
-  target    = aws_instance.access[0].public_ip
+  content    = aws_instance.access[0].public_ip
 }
 
-resource "ovh_domain_zone_record" "www_monitoring" {
-  count = "${var.AccessDocs_vm_enabled ? 1 : 0}"
-  zone      = "multiseb.com"
-  subdomain = "www.monitoring.tpcs"
-  fieldtype = "A"
-  ttl       = 60
-  target    = aws_instance.access[0].public_ip
-}
 
-resource "ovh_domain_zone_record" "prometheus" {
-  count = "${var.AccessDocs_vm_enabled ? 1 : 0}"
-  zone      = "multiseb.com"
-  subdomain = "prometheus.tpcs"
-  fieldtype = "A"
-  ttl       = 60
-  target    = aws_instance.access[0].public_ip
-}
 
-resource "ovh_domain_zone_record" "www_prometheus" {
-  count = "${var.AccessDocs_vm_enabled ? 1 : 0}"
-  zone      = "multiseb.com"
-  subdomain = "www.prometheus.tpcs"
-  fieldtype = "A"
-  ttl       = 60
-  target    = aws_instance.access[0].public_ip
-}
+# resource "cloudflare_dns_record" "test" {
+#   zone_id = var.cloudflare_zone_id
+#   name = "test.${var.dns_subdomain}"
+#   type = "A"
+#   ttl       = 60
+#   content    = "8.8.8.8"
 
-resource "ovh_domain_zone_record" "grafana" {
-  count = "${var.AccessDocs_vm_enabled ? 1 : 0}"
-  zone      = "multiseb.com"
-  subdomain = "grafana.tpcs"
-  fieldtype = "A"
-  ttl       = 60
-  target    = aws_instance.access[0].public_ip
-}
-
-resource "ovh_domain_zone_record" "www_grafana" {
-  count = "${var.AccessDocs_vm_enabled ? 1 : 0}"
-  zone      = "multiseb.com"
-  subdomain = "www.grafana.tpcs"
-  fieldtype = "A"
-  ttl       = 60
-  target    = aws_instance.access[0].public_ip
-}
+#   lifecycle {
+#     ignore_changes = [
+#       comment,
+#       settings,
+#       data
+#     ]
+#   }
+# }

--- a/terraform-infra/firewall.tf
+++ b/terraform-infra/firewall.tf
@@ -28,51 +28,51 @@ resource "aws_security_group" "secgroup" {
 
 resource "aws_security_group_rule" "ssh" {
   type              = "ingress"
-  from_port        = 22
-  to_port          = 22
-  protocol         = "tcp"
-  cidr_blocks      = ["0.0.0.0/0"]
-  ipv6_cidr_blocks = ["::/0"]
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  ipv6_cidr_blocks  = ["::/0"]
   security_group_id = aws_security_group.secgroup.id
 }
 
 resource "aws_security_group_rule" "http" {
   type              = "ingress"
-  from_port        = 80
-  to_port          = 80
-  protocol         = "tcp"
-  cidr_blocks      = ["0.0.0.0/0"]
-  ipv6_cidr_blocks = ["::/0"]
+  from_port         = 80
+  to_port           = 80
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  ipv6_cidr_blocks  = ["::/0"]
   security_group_id = aws_security_group.secgroup.id
 }
 
 resource "aws_security_group_rule" "https" {
   type              = "ingress"
-  from_port        = 443
-  to_port          = 443
-  protocol         = "tcp"
-  cidr_blocks      = ["0.0.0.0/0"]
-  ipv6_cidr_blocks = ["::/0"]
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  ipv6_cidr_blocks  = ["::/0"]
   security_group_id = aws_security_group.secgroup.id
 }
 
 resource "aws_security_group_rule" "guacamole" {
   type              = "ingress"
-  from_port        = 8443
-  to_port          = 8443
-  protocol         = "tcp"
-  cidr_blocks      = ["0.0.0.0/0"]
-  ipv6_cidr_blocks = ["::/0"]
+  from_port         = 8443
+  to_port           = 8443
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  ipv6_cidr_blocks  = ["::/0"]
   security_group_id = aws_security_group.secgroup.id
 }
 
 resource "aws_security_group_rule" "prometheus_exporter" {
   type              = "ingress"
-  from_port        = 9100
-  to_port          = 9100
-  protocol         = "tcp"
-  cidr_blocks      = ["0.0.0.0/0"]
-  ipv6_cidr_blocks = ["::/0"]
+  from_port         = 9100
+  to_port           = 9100
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  ipv6_cidr_blocks  = ["::/0"]
   security_group_id = aws_security_group.secgroup.id
 }
 
@@ -108,91 +108,91 @@ resource "aws_security_group_rule" "grafana" {
 
 resource "aws_security_group_rule" "vikunja_front_port" {
   type              = "ingress"
-  from_port        = 8080
-  to_port          = 8080
-  protocol         = "tcp"
-  cidr_blocks      = ["0.0.0.0/0"]
-  ipv6_cidr_blocks = ["::/0"]
+  from_port         = 8080
+  to_port           = 8080
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  ipv6_cidr_blocks  = ["::/0"]
   security_group_id = aws_security_group.secgroup.id
 }
 
 resource "aws_security_group_rule" "vikunja_api_port" {
   type              = "ingress"
-  from_port        = 3456
-  to_port          = 3456
-  protocol         = "tcp"
-  cidr_blocks      = ["0.0.0.0/0"]
-  ipv6_cidr_blocks = ["::/0"]
+  from_port         = 3456
+  to_port           = 3456
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  ipv6_cidr_blocks  = ["::/0"]
   security_group_id = aws_security_group.secgroup.id
 }
 
 resource "aws_security_group_rule" "node_port_kube_test" {
   type              = "ingress"
-  from_port        = 8888
-  to_port          = 8888
-  protocol         = "tcp"
-  cidr_blocks      = ["0.0.0.0/0"]
-  ipv6_cidr_blocks = ["::/0"]
+  from_port         = 8888
+  to_port           = 8888
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  ipv6_cidr_blocks  = ["::/0"]
   security_group_id = aws_security_group.secgroup.id
 }
 
 resource "aws_security_group_rule" "node_port_kube_test_2" {
   type              = "ingress"
-  from_port        = 8889
-  to_port          = 8889
-  protocol         = "tcp"
-  cidr_blocks      = ["0.0.0.0/0"]
-  ipv6_cidr_blocks = ["::/0"]
+  from_port         = 8889
+  to_port           = 8889
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  ipv6_cidr_blocks  = ["::/0"]
   security_group_id = aws_security_group.secgroup.id
 }
 
 resource "aws_security_group_rule" "node_port_kube3_test" {
   type              = "ingress"
-  from_port        = 30888
-  to_port          = 30888
-  protocol         = "tcp"
-  cidr_blocks      = ["0.0.0.0/0"]
-  ipv6_cidr_blocks = ["::/0"]
+  from_port         = 30888
+  to_port           = 30888
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  ipv6_cidr_blocks  = ["::/0"]
   security_group_id = aws_security_group.secgroup.id
 }
 
 resource "aws_security_group_rule" "xrdp_port" {
   type              = "ingress"
-  from_port        = 3389
-  to_port          = 3389
-  protocol         = "tcp"
-  cidr_blocks      = ["0.0.0.0/0"]
-  ipv6_cidr_blocks = ["::/0"]
+  from_port         = 3389
+  to_port           = 3389
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  ipv6_cidr_blocks  = ["::/0"]
   security_group_id = aws_security_group.secgroup.id
 }
 
 resource "aws_security_group_rule" "micro_k8s_api" {
   type              = "ingress"
-  from_port        = 16443
-  to_port          = 16443
-  protocol         = "tcp"
-  cidr_blocks      = ["0.0.0.0/0"]
-  ipv6_cidr_blocks = ["::/0"]
+  from_port         = 16443
+  to_port           = 16443
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  ipv6_cidr_blocks  = ["::/0"]
   security_group_id = aws_security_group.secgroup.id
 }
 
 resource "aws_security_group_rule" "kube_add_node" {
   type              = "ingress"
-  from_port        = 25000
-  to_port          = 25000
-  protocol         = "tcp"
-  cidr_blocks      = ["0.0.0.0/0"]
-  ipv6_cidr_blocks = ["::/0"]
+  from_port         = 25000
+  to_port           = 25000
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  ipv6_cidr_blocks  = ["::/0"]
   security_group_id = aws_security_group.secgroup.id
 }
 
 # https://erkanerol.github.io/post/how-kubectl-exec-works/
 resource "aws_security_group_rule" "kube_add_node_exec" {
   type              = "ingress"
-  from_port        = 10250
-  to_port          = 10250
-  protocol         = "tcp"
-  cidr_blocks      = ["0.0.0.0/0"]
-  ipv6_cidr_blocks = ["::/0"]
+  from_port         = 10250
+  to_port           = 10250
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  ipv6_cidr_blocks  = ["::/0"]
   security_group_id = aws_security_group.secgroup.id
 }

--- a/terraform-infra/guac-config.tf.toupload
+++ b/terraform-infra/guac-config.tf.toupload
@@ -8,7 +8,7 @@ terraform {
 }
 
 provider "guacamole" {
-  url      = "http://access.tpcs.multiseb.com"
+  url      = "http://access.${dns_subdomain}"
   username = "guacadmin"
   password = "guacadmin"
   # disable_tls_verification = true
@@ -32,10 +32,10 @@ resource "guacamole_user" "user" {
 resource "guacamole_connection_rdp" "rdp" {
   count = ${vm_number}
 
-  name = "$${format("RDP --- vm%02s --- vm%02s.tpcs.multiseb.com",count.index , count.index)}"
+  name = "$${format("RDP --- vm%02s --- vm%02s.${dns_subdomain}",count.index , count.index)}"
   parent_identifier = "ROOT"
   parameters {
-    hostname = "$${format("vm%02s.tpcs.multiseb.com", count.index)}"
+    hostname = "$${format("vm%02s.${dns_subdomain}", count.index)}"
     username = "$${format("vm%02s", count.index)}"
     password = "$${format("vm%02s", count.index)}"
     security_mode = "any"
@@ -50,7 +50,7 @@ resource "guacamole_connection_rdp" "rdp" {
     resize_method = "display-update"
     color_depth = 16
     sftp_enable = true
-    sftp_hostname = "$${format("vm%02s.tpcs.multiseb.com", count.index)}"
+    sftp_hostname = "$${format("vm%02s.${dns_subdomain}", count.index)}"
     sftp_port = 22
     sftp_username = "$${format("vm%02s", count.index)}"
     sftp_password = "$${format("vm%02s", count.index)}"
@@ -65,10 +65,10 @@ resource "guacamole_connection_rdp" "rdp" {
 resource "guacamole_connection_ssh" "ssh" {
   count = ${vm_number}
 
-  name = "$${format("SSH --- vm%02s --- vm%02s.tpcs.multiseb.com", count.index , count.index)}"
+  name = "$${format("SSH --- vm%02s --- vm%02s.${dns_subdomain}", count.index , count.index)}"
   parent_identifier = "ROOT"
   parameters {
-    hostname = "$${format("vm%02s.tpcs.multiseb.com", count.index)}"
+    hostname = "$${format("vm%02s.${dns_subdomain}", count.index)}"
     username = "$${format("vm%02s", count.index)}"
     password = "$${format("vm%02s", count.index)}"
     port = 22

--- a/terraform-infra/iam-users-tpiac.tf
+++ b/terraform-infra/iam-users-tpiac.tf
@@ -2,7 +2,7 @@
 resource "aws_iam_user" "tpiac" {
   count = (var.tp_name == "tpiac" ? var.vm_number : 0 )
 
-  name = format("vm%02s", count.index)
+  name          = format("vm%02s", count.index)
   force_destroy = true
 
   tags = {
@@ -14,13 +14,13 @@ resource "aws_iam_user" "tpiac" {
 resource "aws_iam_user_login_profile" "tpiac" {
   count = (var.tp_name == "tpiac" ? var.vm_number : 0 )
 
-  user    = aws_iam_user.tpiac[count.index].name
+  user = aws_iam_user.tpiac[count.index].name
 }
 
 resource "aws_iam_access_key" "tpiac" {
   count = (var.tp_name == "tpiac" ? var.vm_number : 0 )
 
-  user    = aws_iam_user.tpiac[count.index].name
+  user = aws_iam_user.tpiac[count.index].name
 }
 
 output "tpiac_users" {
@@ -28,9 +28,9 @@ output "tpiac_users" {
   value = (var.tp_name == "tpiac" ?
   [
     for i in range(var.vm_number) : {
-      user_name = aws_iam_user.tpiac[i].name
-      user_pwd  = aws_iam_user_login_profile.tpiac[i].password
-      user_apikey = aws_iam_access_key.tpiac[i].id
+      user_name          = aws_iam_user.tpiac[i].name
+      user_pwd           = aws_iam_user_login_profile.tpiac[i].password
+      user_apikey        = aws_iam_access_key.tpiac[i].id
       user_apikey_secret = aws_iam_access_key.tpiac[i].secret
     }
   ]
@@ -80,72 +80,72 @@ resource "aws_iam_policy" "tpiac" {
   # Terraform's "jsonencode" function converts a
   # Terraform expression result to valid JSON syntax.
   policy = jsonencode({
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": "ec2:*",
-            "Resource": "*",
-            "Condition": {
-                "StringEquals": {
-                    "aws:RequestedRegion": "${var.tpiac_regions_list_for_apikey[count.index]}"
-                }
-            }
-        },
-        {
-            "Effect": "Allow",
-            "Action": "vpc:*",
-            "Resource": "*",
-            "Condition": {
-                "StringEquals": {
-                    "aws:RequestedRegion": "${var.tpiac_regions_list_for_apikey[count.index]}"
-                }
-            }
-        },
-        {
-            "Effect": "Allow",
-            "Action": "elasticloadbalancing:*",
-            "Resource": "*",
-            "Condition": {
-                "StringEquals": {
-                    "aws:RequestedRegion": "${var.tpiac_regions_list_for_apikey[count.index]}"
-                }
-            }
-        },
-        {
-            "Effect": "Allow",
-            "Action": "compute-optimizer:*",
-            "Resource": "*",
-            # "Condition": {
-            #     "StringEquals": {
-            #         "aws:RequestedRegion": "${var.tpiac_regions_list_for_apikey[count.index]}"
-            #     }
-            # }
-            # Needed to avoid error on AWS console (non blocking) about compute-optimizer even if you do not activate it....
-        },
-        {
-            "Effect": "Allow",
-            "Action": "cloudwatch:DescribeAlarms",
-            "Resource": "*",
-            # "Condition": {
-            #     "StringEquals": {
-            #         "aws:RequestedRegion": "${var.tpiac_regions_list_for_apikey[count.index]}"
-            #     }
-            # }
-            # Needed to avoid error on AWS console (non blocking) about compute-optimizer even if you do not activate it....
-        },
-        {
-            "Sid": "AllowManageOwnAccessKeys",
-            "Effect": "Allow",
-            "Action": [
-                "iam:CreateAccessKey",
-                "iam:DeleteAccessKey",
-                "iam:ListAccessKeys",
-                "iam:UpdateAccessKey",
-                "iam:GetAccessKeyLastUsed"
-            ],
-            "Resource": "arn:aws:iam::*:user/$${aws:username}"
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Action" : "ec2:*",
+        "Resource" : "*",
+        "Condition" : {
+          "StringEquals" : {
+            "aws:RequestedRegion" : "${var.tpiac_regions_list_for_apikey[count.index]}"
+          }
         }
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : "vpc:*",
+        "Resource" : "*",
+        "Condition" : {
+          "StringEquals" : {
+            "aws:RequestedRegion" : "${var.tpiac_regions_list_for_apikey[count.index]}"
+          }
+        }
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : "elasticloadbalancing:*",
+        "Resource" : "*",
+        "Condition" : {
+          "StringEquals" : {
+            "aws:RequestedRegion" : "${var.tpiac_regions_list_for_apikey[count.index]}"
+          }
+        }
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : "compute-optimizer:*",
+        "Resource" : "*",
+        # "Condition": {
+        #     "StringEquals": {
+        #         "aws:RequestedRegion": "${var.tpiac_regions_list_for_apikey[count.index]}"
+        #     }
+        # }
+        # Needed to avoid error on AWS console (non blocking) about compute-optimizer even if you do not activate it....
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : "cloudwatch:DescribeAlarms",
+        "Resource" : "*",
+        # "Condition": {
+        #     "StringEquals": {
+        #         "aws:RequestedRegion": "${var.tpiac_regions_list_for_apikey[count.index]}"
+        #     }
+        # }
+        # Needed to avoid error on AWS console (non blocking) about compute-optimizer even if you do not activate it....
+      },
+      {
+        "Sid" : "AllowManageOwnAccessKeys",
+        "Effect" : "Allow",
+        "Action" : [
+          "iam:CreateAccessKey",
+          "iam:DeleteAccessKey",
+          "iam:ListAccessKeys",
+          "iam:UpdateAccessKey",
+          "iam:GetAccessKeyLastUsed"
+        ],
+        "Resource" : "arn:aws:iam::*:user/$${aws:username}"
+      }
     ]
   })
 }

--- a/terraform-infra/providers.tf
+++ b/terraform-infra/providers.tf
@@ -4,8 +4,9 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 4.16"
     }
-    ovh = {
-      source  = "ovh/ovh"
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5"
     }
   }
 
@@ -13,26 +14,16 @@ terraform {
 }
 
 provider "aws" {
-  region  = "eu-west-3" # Paris
+  region = "eu-west-3" # Paris
 }
 
-variable "ovh_endpoint" {
-  type = string
-  default = "ovh-eu"
+provider "cloudflare" {
+  api_token = var.cloudflare_api_token
 }
-variable "ovh_application_key" {
-  type = string
-}
-variable "ovh_application_secret" {
+variable "cloudflare_api_token" {
   type = string
 }
-variable "ovh_consumer_key" {
-  type = string
-}
-
-provider "ovh" {
-  endpoint           = var.ovh_endpoint
-  application_key    = var.ovh_application_key
-  application_secret = var.ovh_application_secret
-  consumer_key       = var.ovh_consumer_key
+variable "cloudflare_zone_id" {
+  type    = string
+  default = "b8d7510b8514176bdc74e713579d1289"
 }

--- a/terraform-infra/scripts/01_check_vms_readiness.sh
+++ b/terraform-infra/scripts/01_check_vms_readiness.sh
@@ -9,12 +9,13 @@ source $(dirname "$0")/../credentials-setup.sh
 
 for i in docs access
 do
-  VM_FQDN="${i}.tpcs.multiseb.com"
+  VM_FQDN="${i}.${TF_VAR_dns_subdomain}"
   max_attempts=60
   echo "VM : ${VM_FQDN}"
   for ((j=1; i<=${max_attempts}; j++))
   do
     echo "          Attempt : ${j} / ${max_attempts} -- SSH connection"
+    # STATUS=$(ssh -i ~/.ssh/preDEV.maas-user.key -o LogLevel=error -o ConnectTimeout=5 -o ConnectionAttempts=1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ubuntu@${VM_FQDN} "sudo cloud-init status")
     STATUS=$(${ssh_quiet} -i $(dirname "$0")/../key -o ConnectTimeout=5 -o ConnectionAttempts=1 access@${VM_FQDN} 'sudo cloud-init status')
     # we need to test the content retruned for cloud init  that should contain done
     # if yes break (otherwise continue)
@@ -41,13 +42,13 @@ done
 for ((i=0; i<$TF_VAR_vm_number; i++))
 do
   digits=$(printf "%02d" $i)
-  VM_FQDN="vm${digits}.tpcs.multiseb.com"
+  VM_FQDN="vm${digits}.${TF_VAR_dns_subdomain}"
   max_attempts=60
   echo "VM : ${VM_FQDN}"
   for ((j=1; i<=${max_attempts}; j++))
   do
     echo "          Attempt : ${j} / ${max_attempts} -- SSH connection"
-    # STATUS=$(ssh -i ~/.ssh/preDEV.maas-user.id_rsa -o LogLevel=error -o ConnectTimeout=5 -o ConnectionAttempts=1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ubuntu@${VM_FQDN} "sudo cloud-init status")
+    # STATUS=$(ssh -i ~/.ssh/preDEV.maas-user.key -o LogLevel=error -o ConnectTimeout=5 -o ConnectionAttempts=1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ubuntu@${VM_FQDN} "sudo cloud-init status")
     STATUS=$(${ssh_quiet} -i $(dirname "$0")/../key -o ConnectTimeout=5 -o ConnectionAttempts=1 vm${digits}@${VM_FQDN} 'sudo cloud-init status')
     # we need to test the content retruned for cloud init  that should contain done
     # if yes break (otherwise continue)

--- a/terraform-infra/scripts/02_check_region_distribution_and_instances.sh
+++ b/terraform-infra/scripts/02_check_region_distribution_and_instances.sh
@@ -8,11 +8,11 @@ for ((i=0; i<$TF_VAR_vm_number; i++))
 do
   digits=$(printf "%02d" $i)
   echo "VM : vm0${i}"
-  # ssh-keygen -f "$(ls ~/.ssh/known_hosts)" -R "vm${digits}.tpcs.multiseb.com" 2&> /dev/null
-  ${ssh_quiet} -i $(pwd)/key vm$digits@vm${digits}.tpcs.multiseb.com 'cat tpcs-iac/.env | grep REGION'
-  export REGION=$(${ssh_quiet} -i $(pwd)/key vm$digits@vm${digits}.tpcs.multiseb.com 'cat tpcs-iac/.env | grep REGION' | awk -F= '{ print $NF }' | tr -d '"')
+  # ssh-keygen -f "$(ls ~/.ssh/known_hosts)" -R "vm${digits}.${TF_VAR_dns_subdomain}" 2&> /dev/null
+  ${ssh_quiet} -i $(pwd)/key vm$digits@vm${digits}.${TF_VAR_dns_subdomain} 'cat tpcs-iac/.env | grep REGION'
+  export REGION=$(${ssh_quiet} -i $(pwd)/key vm$digits@vm${digits}.${TF_VAR_dns_subdomain} 'cat tpcs-iac/.env | grep REGION' | awk -F= '{ print $NF }' | tr -d '"')
   echo $REGION
-  ${ssh_quiet} -i $(pwd)/key vm$digits@vm${digits}.tpcs.multiseb.com aws --region ${REGION} ec2 describe-instances | jq -r '.Reservations[].Instances[] | "\(.Tags[] | select(.Key=="Name").Value) \(.State.Name) in \(.Placement.AvailabilityZone)"'
+  ${ssh_quiet} -i $(pwd)/key vm$digits@vm${digits}.${TF_VAR_dns_subdomain} aws --region ${REGION} ec2 describe-instances | jq -r '.Reservations[].Instances[] | "\(.Tags[] | select(.Key=="Name").Value) \(.State.Name) in \(.Placement.AvailabilityZone)"'
   echo "-----------"
   echo ""
 done

--- a/terraform-infra/scripts/05_check_knodes.sh
+++ b/terraform-infra/scripts/05_check_knodes.sh
@@ -8,13 +8,13 @@ source $(dirname "$0")/../credentials-setup.sh
 for ((i=0; i<$TF_VAR_vm_number; i++))
 do
   digits=$(printf "%02d" $i)
-  VM_FQDN="knode${digits}.tpcs.multiseb.com"
+  VM_FQDN="knode${digits}.${TF_VAR_dns_subdomain}"
   max_attempts=60
   echo "VM : ${VM_FQDN}"
   for ((j=1; i<=${max_attempts}; j++))
   do
     echo "          Attempt : ${j} / ${max_attempts} -- SSH connection"
-    # STATUS=$(ssh -i ~/.ssh/preDEV.maas-user.id_rsa -o LogLevel=error -o ConnectTimeout=5 -o ConnectionAttempts=1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ubuntu@${VM_FQDN} "sudo cloud-init status")
+    # STATUS=$(ssh -i ~/.ssh/preDEV.maas-user.key -o LogLevel=error -o ConnectTimeout=5 -o ConnectionAttempts=1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ubuntu@${VM_FQDN} "sudo cloud-init status")
     STATUS=$(${ssh_quiet} -i $(dirname "$0")/../key -o ConnectTimeout=5 -o ConnectionAttempts=1 vm${digits}@${VM_FQDN} 'sudo cloud-init status')
     # we need to test the content retruned for cloud init  that should contain done
     # if yes break (otherwise continue)

--- a/terraform-infra/scripts/06_join_microk8S_nodes.sh
+++ b/terraform-infra/scripts/06_join_microk8S_nodes.sh
@@ -9,16 +9,16 @@ source $(dirname "$0")/../credentials-setup.sh
 for ((i=0; i<1; i++))
 do
   digits=$(printf "%02d" $i)
-  VM_FQDN="vm${digits}.tpcs.multiseb.com"
+  VM_FQDN="vm${digits}.${TF_VAR_dns_subdomain}"
 
   echo "VM : ${VM_FQDN}"
   echo "Connect to 'master' VM to get result of join command (token)"
   JOIN_CMD=$(${ssh_quiet} -o ConnectTimeout=5 -o ConnectionAttempts=1 -i $(dirname "$0")/../key vm${digits}@${VM_FQDN} 'microk8s add-node --format json | jq -r .urls[0]')
   echo ${JOIN_CMD}
 
-  echo "VM : knode${digits}.tpcs.multiseb.com"
+  echo "VM : knode${digits}.${TF_VAR_dns_subdomain}"
   echo "Connect to 'node' VM to launch join command"
-  ${ssh_quiet} -o ConnectTimeout=5 -o ConnectionAttempts=1 -i $(dirname "$0")/../key vm${digits}@knode${digits}.tpcs.multiseb.com ''microk8s join ${JOIN_CMD} --worker''
+  ${ssh_quiet} -o ConnectTimeout=5 -o ConnectionAttempts=1 -i $(dirname "$0")/../key vm${digits}@knode${digits}.${TF_VAR_dns_subdomain} ''microk8s join ${JOIN_CMD} --worker''
 
   echo "========================================="
 

--- a/terraform-infra/scripts/07_check_letsencrypt_certificates.sh
+++ b/terraform-infra/scripts/07_check_letsencrypt_certificates.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+DOMAIN="tpcsonline.org"
+SEVEN_DAYS_AGO=$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%S)
+
+# On récupère l'output JSON filtré dans une variable
+CERTS_LIST=$(curl -s "https://crt.sh/?q=%25.${DOMAIN}&output=json" | \
+  jq --arg date_limit "$SEVEN_DAYS_AGO" '
+    map(select(
+      (.issuer_name | test("Let.s Encrypt")) and
+      (.not_before >= $date_limit)
+    ))
+  '
+)
+
+# Nombre total de certificats
+CERT_COUNT=$(echo "$CERTS_LIST" | jq 'length')
+
+# Affichage
+echo "Nombre de certificats Let's Encrypt émis pour $DOMAIN dans les 7 derniers jours : $CERT_COUNT"
+echo
+echo "Liste des certificats et date de délivrance :"
+echo "$CERTS_LIST" | jq -r '
+  .[] | "\(.common_name) | \(.not_before)"
+'
+echo
+echo "Nombre de certificats Let's Encrypt émis pour $DOMAIN dans les 7 derniers jours : $CERT_COUNT"
+
+
+# https://letsencrypt.org/docs/rate-limits/#new-certificates-per-registered-domain

--- a/terraform-infra/variables.tf
+++ b/terraform-infra/variables.tf
@@ -1,16 +1,22 @@
 variable "vm_number" {
-  type = number
+  type    = number
   default = 0
 }
 
 variable "monitoring_user" {
-  type = string
+  type        = string
   description = "username for grafana login"
 }
 
 variable "tpcsws_branch_name" {
-  type = string
-  description = "branch of tpcs-workstation git repo"
+  type        = string
+  description = "branch of tpcs-workstations git repo"
+}
+
+variable "tpcsws_git_repo" {
+  type        = string
+  description = "github repo where this code is hosted. Used in case this git repo would be forked to get some raw files from vms"
+  default     = "seb54000/tpcs-workstations"
 }
 
 variable "acme_certificates_enable" {
@@ -19,22 +25,34 @@ variable "acme_certificates_enable" {
 }
 
 variable "AccessDocs_vm_enabled" {
-  type = bool
+  type    = bool
   default = true
 }
 
-variable "kube_multi_node" {
+variable "copy_from_gdrive" {
   type = bool
+  default = false
+  description = "Decide if copy of TP documents on docs vm will be done automatically from Gdrive"
+}
+
+variable "kube_multi_node" {
+  type    = bool
   default = false
 }
 
 variable "token_gdrive" {
   type = string
   description = "token for gdrive API call in base64 format"
+  default = "faketoken"
+}
+
+variable "dns_subdomain" {
+  type = string
+  description = "You shoud only use tpcsonline.org when you're doing class"
 }
 
 variable "tp_name" {
-  type = string
+  type        = string
   description = "tp type to choose user_data (tpkube or tpiac)"
 }
 
@@ -60,7 +78,7 @@ variable "student_vm_flavor" {
 }
 
 variable "tpiac_docs_file_list" {
-  type = string
+  type    = string
   default = <<EOF
   [
     "TP IAC 00 slides INTRO",
@@ -73,7 +91,7 @@ EOF
 
 
 variable "tpkube_docs_file_list" {
-  type = string
+  type    = string
   default = <<EOF
   [
     "TP KUBE 00 slides INTRO",
@@ -102,7 +120,7 @@ variable "ami_for_template_with_regions_list" {
   type = list(string)
   default = [
     # List done with https://cloud-images.ubuntu.com/locator/ec2/ Noble 24.04 + amd64
-    "ami-05d9d500849d3fece", #"eu-central-1",
+    "ami-0c4059cd09929aebe", #"eu-central-1",
     "ami-0b0087db031e71474", #"eu-west-1",
     "ami-0d3b447228dab952e", #"eu-west-2",
     "ami-061bdb40c12e7d8f1", #"eu-south-1",

--- a/terraform-infra/vm-access-docs.tf
+++ b/terraform-infra/vm-access-docs.tf
@@ -4,13 +4,13 @@ locals {
 }
 
 data "cloudinit_config" "access" {
-  count = "${var.AccessDocs_vm_enabled ? 1 : 0}"
+  count = var.AccessDocs_vm_enabled ? 1 : 0
 
   gzip          = true
   base64_encode = true
 
   part {
-    filename     = "common-cloud-init.sh"
+    filename = "common-cloud-init.sh"
     # common-cloud-init should be in /var/lib/cloud/instance/scripts
     content_type = "text/x-shellscript"
 
@@ -21,7 +21,7 @@ data "cloudinit_config" "access" {
   }
 
   part {
-    filename     = "access-cloud-init.sh"
+    filename = "access-cloud-init.sh"
     # access-cloud-init should be in /var/lib/cloud/instance/scripts
     content_type = "text/x-shellscript"
 
@@ -30,11 +30,13 @@ data "cloudinit_config" "access" {
       {
         guac_tf_file = base64encode(templatefile(
           "guac-config.tf.toupload",
-          { vm_number = var.vm_number }
+          { vm_number = var.vm_number, dns_subdomain = var.dns_subdomain }
         )),
-        username = "access",
+        username           = "access",
         tpcsws_branch_name = var.tpcsws_branch_name,
-        acme_certificates_enable = var.acme_certificates_enable
+        tpcsws_git_repo = var.tpcsws_git_repo,
+        acme_certificates_enable = var.acme_certificates_enable,
+        copy_from_gdrive = var.copy_from_gdrive, dns_subdomain = var.dns_subdomain
       }
     )
   }
@@ -52,12 +54,12 @@ data "cloudinit_config" "access" {
         custom_snaps = ["certbot --classic"]
         custom_files = [
           {
-            content=base64gzip(file("cloudinit/access_docs_nginx.conf"))
+            content=base64gzip(templatefile("cloudinit/access_docs_nginx.conf.tpl", {dns_subdomain = var.dns_subdomain}))
             path="/etc/nginx/sites-enabled/default"
           },
           {
-            content=base64gzip(templatefile("cloudinit/gdrive.py",{file_list = local.file_list}))
-            path="/var/tmp/gdrive.py"
+            content = base64gzip(templatefile("cloudinit/gdrive.py", { file_list = local.file_list }))
+            path    = "/var/tmp/gdrive.py"
           },
           # {
           #   content=base64gzip("<?php phpinfo(); ?>")
@@ -74,20 +76,20 @@ data "cloudinit_config" "access" {
           #   path="/root/vms.php"
           # },
           {
-            content=base64gzip(templatefile("cloudinit/prometheus_config.tftpl",{vm_number = var.vm_number}))
+            content=base64gzip(templatefile("cloudinit/prometheus_config.tftpl",{vm_number = var.vm_number, dns_subdomain = var.dns_subdomain}))
             path="/var/tmp/prometheus.yml"
           },
           {
-            content=base64gzip(templatefile("cloudinit/monitoring_docker_compose.yml",{monitoring_user = var.monitoring_user}))
-            path="/var/tmp/monitoring_docker_compose.yml"
+            content = base64gzip(templatefile("cloudinit/monitoring_docker_compose.yml", { monitoring_user = var.monitoring_user }))
+            path    = "/var/tmp/monitoring_docker_compose.yml"
           },
           {
-            content=base64gzip(file("cloudinit/monitoring_grafana_prom_ds.yml"))
-            path="/var/tmp/grafana-provisioning/datasources/monitoring_grafana_prom_ds.yml"
+            content = base64gzip(file("cloudinit/monitoring_grafana_prom_ds.yml"))
+            path    = "/var/tmp/grafana-provisioning/datasources/monitoring_grafana_prom_ds.yml"
           },
           {
-            content=base64gzip(file("cloudinit/monitoring_grafana_dashboards_conf.yml"))
-            path="/var/tmp/grafana-provisioning/dashboards/monitoring_grafana_dashboards_conf.yml"
+            content = base64gzip(file("cloudinit/monitoring_grafana_dashboards_conf.yml"))
+            path    = "/var/tmp/grafana-provisioning/dashboards/monitoring_grafana_dashboards_conf.yml"
           },
           # Grafana dashboards are too big and will be upload through git clone (or through access to raw file)
           # {
@@ -99,16 +101,20 @@ data "cloudinit_config" "access" {
           #   path="/var/tmp/grafana/dashboards/monitoring_grafana_node_full_dashboard.json"
           # },
           {
-            content=base64gzip(templatefile("cloudinit/users.json.tftpl",{users_list = var.users_list}))
-            path="/var/www/html/json/users.json"
+            content = base64gzip(templatefile("cloudinit/users.json.tftpl", { users_list = var.users_list }))
+            path    = "/var/www/html/json/users.json"
           },
           {
             content = var.tp_name == "tpiac" ? base64gzip(templatefile("cloudinit/api_keys.json.tftpl",{access_key = aws_iam_access_key.tpiac, vm_number = var.vm_number})) : base64gzip("fakecontentwhentp_nameis nottpiac")
             path = "/var/www/html/json/api_keys.json"
           },
           {
-            content=base64gzip(var.tp_name)
-            path="/var/www/html/json/tp_name"
+            content = base64gzip(var.tp_name)
+            path    = "/var/www/html/json/tp_name"
+          },
+          {
+            content = base64gzip(var.dns_subdomain)
+            path    = "/var/www/html/json/dns_subdomain"
           }
           # {
           #   content=base64gzip(file("cloudinit/quotas.php"))
@@ -126,23 +132,23 @@ data "cloudinit_config" "access" {
 }
 
 resource "aws_instance" "access" {
-  count = "${var.AccessDocs_vm_enabled ? 1 : 0}"
+  count = var.AccessDocs_vm_enabled ? 1 : 0
 
   ami             = "ami-01d21b7be69801c2f"   # eu-west-3 : Ubuntu 22.04 LTS Jammy jellifish -- https://cloud-images.ubuntu.com/locator/ec2/
   instance_type = var.access_docs_flavor
   subnet_id              = aws_subnet.public_subnet.id
   vpc_security_group_ids = [aws_security_group.secgroup.id]
-  key_name      = aws_key_pair.tpcs_key.key_name
-  user_data     = data.cloudinit_config.access[0].rendered
-  iam_instance_profile = "${aws_iam_instance_profile.access[0].name}"
+  key_name               = aws_key_pair.tpcs_key.key_name
+  user_data              = data.cloudinit_config.access[0].rendered
+  iam_instance_profile   = aws_iam_instance_profile.access[0].name
 
   root_block_device {
     volume_size = 50
   }
 
   tags = {
-    Name = "access_docs"
-    dns_record = "ovh_domain_zone_record.access[*].subdomain"
+    Name       = "access_docs"
+    dns_record = "cloudflare_dns_record.access[*].name"
     other_name = "guacamole"
   }
 
@@ -152,17 +158,17 @@ resource "aws_instance" "access" {
 }
 
 resource "aws_ec2_instance_state" "access" {
-  count = "${var.AccessDocs_vm_enabled ? 1 : 0}"
+  count       = var.AccessDocs_vm_enabled ? 1 : 0
   instance_id = aws_instance.access[0].id
   state       = "running"
 }
 
 output "access" {
-    value = [
+  value = [
     {
-    "public_ip" = join("", aws_instance.access.*.public_ip)
-    # "name" = aws_instance.access[*].tags["Name"]
-    "dns" = join("", ovh_domain_zone_record.access.*.subdomain)
+      "public_ip" = join("", aws_instance.access.*.public_ip)
+      # "name" = aws_instance.access[*].tags["Name"]
+      "dns" = join("", cloudflare_dns_record.access.*.name)
     }
   ]
 }
@@ -172,64 +178,64 @@ output "access" {
 ## IAM role management to allow this instance to call EC2 API (to list VMs and other php scripts)
 # https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html
 resource "aws_iam_role" "access" {
-  count = "${var.AccessDocs_vm_enabled ? 1 : 0}"
-  name = "access"
+  count = var.AccessDocs_vm_enabled ? 1 : 0
+  name  = "access"
 
   assume_role_policy = jsonencode(
     {
-      "Version": "2012-10-17",
-      "Statement": [
+      "Version" : "2012-10-17",
+      "Statement" : [
         {
-          "Action": "sts:AssumeRole",
-          "Principal": {
-            "Service": "ec2.amazonaws.com"
+          "Action" : "sts:AssumeRole",
+          "Principal" : {
+            "Service" : "ec2.amazonaws.com"
           },
-          "Effect": "Allow",
-          "Sid": ""
+          "Effect" : "Allow",
+          "Sid" : ""
         }
       ]
     }
   )
 
   tags = {
-      name = "access-tpcs"
+    name = "access-tpcs"
   }
 }
 
 resource "aws_iam_instance_profile" "access" {
-  count = "${var.AccessDocs_vm_enabled ? 1 : 0}"
-  name = "access"
-  role = "${aws_iam_role.access[0].name}"
+  count = var.AccessDocs_vm_enabled ? 1 : 0
+  name  = "access"
+  role  = aws_iam_role.access[0].name
 }
 
 resource "aws_iam_policy" "access" {
-  count = "${var.AccessDocs_vm_enabled ? 1 : 0}"
-  name = "access"
+  count = var.AccessDocs_vm_enabled ? 1 : 0
+  name  = "access"
 
   policy = jsonencode(
     {
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Effect": "Allow",
-                "Action": ["ec2:DescribeTags", "ec2:DescribeInstances", "ec2:DescribeRegions", "ec2:DescribeAccountAttributes", "servicequotas:*", "iam:ListGroupsForUser"],
-                "Resource": "*"
-            }
-            # TOOO add authorization to request IAM informations including AK/SK ?
-            #,
-            # {
-            #     "Effect": "Allow",
-            #     "Action": "route53:ChangeResourceRecordSets",
-            #     "Resource": "arn:aws:route53:::hostedzone/${data.aws_route53_zone.tpkube.zone_id}"
-            # }
-        ]
+      "Version" : "2012-10-17",
+      "Statement" : [
+        {
+          "Effect" : "Allow",
+          "Action" : ["ec2:DescribeTags", "ec2:DescribeInstances", "ec2:DescribeRegions", "ec2:DescribeAccountAttributes", "servicequotas:*", "iam:ListGroupsForUser"],
+          "Resource" : "*"
+        }
+        # TOOO add authorization to request IAM informations including AK/SK ?
+        #,
+        # {
+        #     "Effect": "Allow",
+        #     "Action": "route53:ChangeResourceRecordSets",
+        #     "Resource": "arn:aws:route53:::hostedzone/${data.aws_route53_zone.tpkube.zone_id}"
+        # }
+      ]
     }
   )
 }
 
 resource "aws_iam_policy_attachment" "access" {
-  count = "${var.AccessDocs_vm_enabled ? 1 : 0}"
+  count      = var.AccessDocs_vm_enabled ? 1 : 0
   name       = "access"
   roles      = ["${aws_iam_role.access[0].name}"]
-  policy_arn = "${aws_iam_policy.access[0].arn}"
+  policy_arn = aws_iam_policy.access[0].arn
 }

--- a/terraform-infra/vpc-subnets.tf
+++ b/terraform-infra/vpc-subnets.tf
@@ -7,14 +7,14 @@ resource "aws_vpc" "vpc" {
   assign_generated_ipv6_cidr_block = true
 
   tags = {
-    Name        = "infra-tp-vpc"
+    Name = "infra-tp-vpc"
   }
 }
 
 resource "aws_internet_gateway" "gw" {
   vpc_id = aws_vpc.vpc.id
   tags = {
-    Name        = "infra-tp"
+    Name = "infra-tp"
   }
 }
 
@@ -22,7 +22,7 @@ resource "aws_route_table" "internet" {
   vpc_id = aws_vpc.vpc.id
 
   tags = {
-    Name        = "infra-tp"
+    Name = "infra-tp"
   }
   route {
     cidr_block = "0.0.0.0/0"
@@ -38,14 +38,14 @@ resource "aws_route_table" "internet" {
 }
 
 resource "aws_subnet" "public_subnet" {
-  cidr_block                      = "10.1.1.0/24"
-  vpc_id                          = aws_vpc.vpc.id
-  map_public_ip_on_launch         = true
+  cidr_block              = "10.1.1.0/24"
+  vpc_id                  = aws_vpc.vpc.id
+  map_public_ip_on_launch = true
 
   availability_zone = "eu-west-3a"
 
   tags = {
-    Name        = "infra-tp-public"
+    Name = "infra-tp-public"
   }
 }
 
@@ -58,8 +58,8 @@ resource "aws_route_table_association" "public_routing_table" {
 resource "aws_eip" "nat_gateway" {
   # domain = "vpc"
   tags = {
-    Name        = "infra-tp-natgw"
-  }  
+    Name = "infra-tp-natgw"
+  }
 }
 
 resource "aws_nat_gateway" "nat_gw" {
@@ -76,10 +76,10 @@ resource "aws_nat_gateway" "nat_gw" {
 resource "aws_route_table" "nat_gateway" {
   vpc_id = aws_vpc.vpc.id
   tags = {
-    Name        = "infra-tp"
+    Name = "infra-tp"
   }
   route {
-    cidr_block = "0.0.0.0/0"
+    cidr_block     = "0.0.0.0/0"
     nat_gateway_id = aws_nat_gateway.nat_gw.id
   }
   # route {


### PR DESCRIPTION
- [X] Add acme_certificates_enable variable to choose if we want real ACME certificates or selfsigned (because when doing multiple create and destroy tests, we can block the certificates issuance as it is limited to a certain number)
- [X] Add a copy_from_gdrive var to decide if documents should be automatically copied form Gdrive to docs (needs grdive token)
- [X] Remove the vms with a status of terminated (removed) in the vms.php listing
- [X] Use a tpcsonline.org domain on Cloudflare more reliable than OVH
  - [X] add a dns_subdomain var to enable parralel working like access.xxx.tpcsonline.org
- [X] Add a script (07) to check certificates delivered in the last 7 days (to check letsencrypt limit)